### PR TITLE
Fix warning message

### DIFF
--- a/2nd-edition/ch04/ex7-countdown/lib/count.ex
+++ b/2nd-edition/ch04/ex7-countdown/lib/count.ex
@@ -5,7 +5,7 @@ defmodule Count do
     countdown(from-1)
   end
 
-  def countdown(from) do
+  def countdown(_from) do
     IO.puts("blastoff!")
   end
 


### PR DESCRIPTION
Fix warning message (unused variable by using underscore)